### PR TITLE
chore: configura package.json para publicación en npm v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ y este proyecto sigue [Versionado Semántico](https://semver.org/lang/es/).
 - Dependencias de producción: cero (se elimina `core-js`)
 - Dependencias de desarrollo: `@babel/cli`, `@babel/core`, `@babel/preset-env`, `babel-eslint`
 - Archivos obsoletos: `index.js`, `.babelrc`, `.eslintrc.js`, `yarn.lock`, `dist/`
+- Referencia al por el autor original:
+  licencia cambiada de ISC a **MIT**, titular Andrés Saá Narváez
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,18 @@ y este proyecto sigue [Versionado Semántico](https://semver.org/lang/es/).
 - Apócope interno automático al componer escalas en masculino
   (`vigésimo primer milésimo`, no `vigésimo primero milésimo`)
 - Género femenino correcto en números grandes (`vigésima primera milésima`)
+- Compatibilidad dual: `require('ordinales-js')` y `import { toOrdinal } from 'ordinales-js'`
+  funcionan sin pasos de build adicionales
 - Workflow de CI con GitHub Actions (Node 18, 20 y 22)
-- Campo `exports` y `engines` en `package.json`
+- Campos `exports`, `engines` y `files` en `package.json`
+- Script `prepublishOnly` para validar tests antes de cada publicación en npm
 
 ### Cambiado
-- **ROTURA**: La librería ahora usa ES Modules (`import/export`). Requiere Node ≥ 18
-- **ROTURA**: `require('ordinales-js')` ya no funciona; usar `import { toOrdinal } from 'ordinales-js'`
+- **ROTURA**: Requiere Node ≥ 18
 - Tests migrados a `node:test` (integrado en Node, sin dependencias extra)
-- ESLint migrado a flat config (`eslint.config.js`)
+- ESLint migrado a flat config (`eslint.config.cjs`)
 - Gestor de paquetes cambiado de yarn a npm
-- Versión mínima de Node establecida en 18
+- Lockfiles excluidos del repositorio (práctica recomendada para librerías públicas)
 
 ### Eliminado
 - Dependencias de producción: cero (se elimina `core-js`)

--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,21 @@
-Internet Systems Consortium license
-===================================
+MIT License
 
-Copyright (c) 2019, Jampink Consulting SL
+Copyright (c) 2026 Andrés Saá Narváez
 
-Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Source: http://opensource.org/licenses/ISC
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/AndresSaa/ordinales-js/actions/workflows/ci.yml/badge.svg)](https://github.com/AndresSaa/ordinales-js/actions/workflows/ci.yml)
 [![Version](https://img.shields.io/npm/v/ordinales-js.svg)](https://www.npmjs.com/package/ordinales-js)
-[![License](https://img.shields.io/npm/l/ordinales-js.svg)](https://www.npmjs.com/package/ordinales-js)
+[![License](https://img.shields.io/badge/licencia-MIT-blue)](./LICENSE)
 [![Downloads](https://img.shields.io/npm/dm/ordinales-js.svg)](https://npmcharts.com/compare/ordinales-js?minimal=true)
 [![Node](https://img.shields.io/node/v/ordinales-js)](https://www.npmjs.com/package/ordinales-js)
 [![Bundle size](https://img.shields.io/bundlephobia/minzip/ordinales-js)](https://bundlephobia.com/package/ordinales-js)

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "script"
   ],
   "author": "Andres Saa Narvaez <andres.saa.narvaez@gmail.com>",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/AndresSaa/ordinales-js/issues"
   },

--- a/package.json
+++ b/package.json
@@ -9,13 +9,17 @@
       "import": "./src/ordinales.mjs"
     }
   },
+  "files": [
+    "src/"
+  ],
   "engines": {
     "node": ">=18.0.0"
   },
   "scripts": {
     "test": "node --test test.mjs",
     "lint": "eslint src",
-    "demo": "node demo.mjs"
+    "demo": "node demo.mjs",
+    "prepublishOnly": "npm test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Resumen

Prepara el paquete para su publicación en npm como v2.0.0.

## Cambios

- **`files`**: limita lo que se publica a `src/` únicamente.
  Quedan excluidos `assets/`, `test.mjs`, `demo.mjs` y `.github/`
- **`prepublishOnly`**: ejecuta `npm test` automáticamente antes de
  cada `npm publish`. Si los tests fallan, el publish se cancela

## Contenido del paquete

```
ordinales-js@2.0.0
├── LICENSE
├── README.md
├── package.json
└── src/
    ├── enhance.js
    ├── ordinales.js   ← CJS
    └── ordinales.mjs  ← wrapper ESM
```

## Publicar tras mergear

```bash
npm login   # si no estás logueado
npm publish
```