### PR TITLE
feat: tipos TypeScript, casos de borde y bump a v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ y este proyecto sigue [Versionado Semántico](https://semver.org/lang/es/).
 
 ---
 
+## [2.1.0] - 2026-05-15
+
+### Añadido
+- Tipos TypeScript (`src/ordinales.d.ts`): `OrdinalGender`, `OrdinalOptions`, `toOrdinal`, `enhance`
+- Campos `types` y `exports.types` en `package.json` apuntando al `.d.ts`
+- Manejo explícito de casos de borde en `toOrdinal`:
+  - `0` y negativos devuelven `''`
+  - Floats se truncan con `Math.trunc` (`1.9` → `'primero'`)
+  - Tipos inválidos (`NaN`, `string`, `null`, `undefined`, objetos, arrays) lanzan `TypeError`
+- Nuevos tests: tres bloques de casos de borde (valores sin ordinal, floats, tipos inválidos)
+- Sección "Casos de borde" en el README con tabla de comportamiento
+
+### Cambiado
+- Entry point movido a `src/index.js` (reexporta `ordinales.js`); `main` y `exports.require` actualizados
+- `.travis.yml` eliminado (CI cubierto por GitHub Actions)
+
+---
+
 ## [2.0.0] - 2026-05-14
 
 ### Añadido

--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ numero.toOrdinal({ gender: 'f' })         // 'vigésima primera'
 numero.toOrdinal({ apocope: true })       // 'vigésimo primer'
 ```
 
+## Casos de borde
+
+| Llamada | Resultado |
+|---------|-----------|
+| `toOrdinal(0)` | `''` — cero no tiene ordinal en español |
+| `toOrdinal(-5)` | `''` — los negativos tampoco |
+| `toOrdinal(1.7)` | `'primero'` — los decimales se truncan (`Math.trunc`) |
+| `toOrdinal(NaN)` | lanza `TypeError` |
+| `toOrdinal('foo')` | lanza `TypeError` |
+| `toOrdinal(null)` | lanza `TypeError` |
+| `toOrdinal(undefined)` | lanza `TypeError` |
+| `toOrdinal({ gender: 'f' })` | lanza `TypeError` — objeto pasado como número |
+
 ## Demo
 
 ```bash

--- a/demo.mjs
+++ b/demo.mjs
@@ -15,3 +15,27 @@ numeros.forEach(n => {
 })
 
 console.log("\n----------------------------------\n")
+
+console.log("--- CASOS DE BORDE ---\n")
+
+const edgeCases = [
+  { label: 'toOrdinal(0)',               call: () => toOrdinal(0) },
+  { label: 'toOrdinal(-5)',              call: () => toOrdinal(-5) },
+  { label: 'toOrdinal(1.9)',             call: () => toOrdinal(1.9) },
+  { label: 'toOrdinal(21.7)',            call: () => toOrdinal(21.7) },
+  { label: "toOrdinal('foo')",           call: () => toOrdinal('foo') },
+  { label: 'toOrdinal(null)',            call: () => toOrdinal(null) },
+  { label: 'toOrdinal(undefined)',       call: () => toOrdinal(undefined) },
+  { label: 'toOrdinal(NaN)',             call: () => toOrdinal(NaN) },
+  { label: "toOrdinal({ gender: 'f' })", call: () => toOrdinal({ gender: 'f' }) },
+]
+
+edgeCases.forEach(({ label, call }) => {
+  try {
+    console.log(`${label.padEnd(30)} → '${call()}'`)
+  } catch (e) {
+    console.log(`${label.padEnd(30)} → ${e.constructor.name}: ${e.message}`)
+  }
+})
+
+console.log("\n----------------------------------\n")

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "ordinales-js",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Librería para convertir números cardinales en ordinales",
   "main": "./src/index.js",
+  "types": "./src/ordinales.d.ts",
   "exports": {
     ".": {
       "require": "./src/index.js",
-      "import": "./src/ordinales.mjs"
+      "import": "./src/ordinales.mjs",
+      "types": "./src/ordinales.d.ts"
     }
   },
   "files": [

--- a/src/ordinales.d.ts
+++ b/src/ordinales.d.ts
@@ -1,0 +1,9 @@
+export type OrdinalGender = 'm' | 'f'
+
+export interface OrdinalOptions {
+  gender?: OrdinalGender
+  apocope?: boolean
+}
+
+export function toOrdinal(n: number, options?: OrdinalGender | OrdinalOptions): string
+export function enhance(): void

--- a/src/ordinales.js
+++ b/src/ordinales.js
@@ -57,11 +57,14 @@ const buildParts = (n, gender = 'm') => {
 }
 
 // Convierte un número a su forma ordinal en español, con opciones de género y apócope
-const toOrdinal = (number = 0, options = 'm') => {
+const toOrdinal = (number, options = 'm') => {
+  if (typeof number !== 'number' || isNaN(number)) throw new TypeError(`toOrdinal: se esperaba un número, se recibió ${typeof number}`)
+
+  const n       = Math.trunc(number)
   const gender  = typeof options === 'object' ? (options.gender  ?? 'm')   : options
   const apocope = typeof options === 'object' ? (options.apocope ?? false) : false
 
-  const ordinal = buildParts(number, gender)
+  const ordinal = buildParts(n, gender)
     .map(part => gender === 'f' ? part.slice(0, -1) + 'a' : part)
     .join(' ')
 

--- a/test.mjs
+++ b/test.mjs
@@ -3,10 +3,10 @@ import assert from 'node:assert/strict'
 import { toOrdinal } from './src/index.js'
 
 test('ordinales básicos', () => {
-  assert.strictEqual(toOrdinal(1),               'primero')
-  assert.strictEqual(toOrdinal(3),               'tercero')
-  assert.strictEqual(toOrdinal(1, 'f'),          'primera')
-  assert.strictEqual(toOrdinal(21),              'vigésimo primero')
+  assert.strictEqual(toOrdinal(1),      'primero')
+  assert.strictEqual(toOrdinal(3),      'tercero')
+  assert.strictEqual(toOrdinal(1, 'f'), 'primera')
+  assert.strictEqual(toOrdinal(21),     'vigésimo primero')
 })
 
 test('género mediante objeto de opciones', () => {
@@ -32,18 +32,39 @@ test('apócope no aplica en femenino ni sin terminación especial', () => {
 })
 
 test('números grandes — miles', () => {
-  assert.strictEqual(toOrdinal(9999),                          'nuevemilésimo noningentésimo nonagésimo noveno')
-  assert.strictEqual(toOrdinal(10000),                         'décimo milésimo')
-  assert.strictEqual(toOrdinal(21000),                         'vigésimo primer milésimo')
-  assert.strictEqual(toOrdinal(21000, 'f'),                    'vigésima primera milésima')
-  assert.strictEqual(toOrdinal(21000, { apocope: true }),      'vigésimo primer milésimo')
-  assert.strictEqual(toOrdinal(100000),                        'centésimo milésimo')
-  assert.strictEqual(toOrdinal(123456),                        'centésimo vigésimo tercer milésimo cuadrigentésimo quincuagésimo sexto')
+  assert.strictEqual(toOrdinal(9999),                     'nuevemilésimo noningentésimo nonagésimo noveno')
+  assert.strictEqual(toOrdinal(10000),                    'décimo milésimo')
+  assert.strictEqual(toOrdinal(21000),                    'vigésimo primer milésimo')
+  assert.strictEqual(toOrdinal(21000, 'f'),               'vigésima primera milésima')
+  assert.strictEqual(toOrdinal(21000, { apocope: true }), 'vigésimo primer milésimo')
+  assert.strictEqual(toOrdinal(100000),                   'centésimo milésimo')
+  assert.strictEqual(toOrdinal(123456),                   'centésimo vigésimo tercer milésimo cuadrigentésimo quincuagésimo sexto')
 })
 
 test('números grandes — millones', () => {
-  assert.strictEqual(toOrdinal(1000000),                          'millonésimo')
-  assert.strictEqual(toOrdinal(2000000),                          'dosmillonésimo')
-  assert.strictEqual(toOrdinal(21000000, { apocope: true }),      'vigésimo primer millonésimo')
-  assert.strictEqual(toOrdinal(21000000, 'f'),                    'vigésima primera millonésima')
+  assert.strictEqual(toOrdinal(1000000),                     'millonésimo')
+  assert.strictEqual(toOrdinal(2000000),                     'dosmillonésimo')
+  assert.strictEqual(toOrdinal(21000000, { apocope: true }), 'vigésimo primer millonésimo')
+  assert.strictEqual(toOrdinal(21000000, 'f'),               'vigésima primera millonésima')
+})
+
+test('casos de borde — valores sin ordinal', () => {
+  assert.strictEqual(toOrdinal(0),  '')
+  assert.strictEqual(toOrdinal(-1), '')
+  assert.strictEqual(toOrdinal(-999), '')
+})
+
+test('casos de borde — floats se truncan', () => {
+  assert.strictEqual(toOrdinal(1.9),  'primero')
+  assert.strictEqual(toOrdinal(3.1),  'tercero')
+  assert.strictEqual(toOrdinal(21.7), 'vigésimo primero')
+})
+
+test('casos de borde — tipos inválidos lanzan TypeError', () => {
+  assert.throws(() => toOrdinal(NaN),             TypeError)
+  assert.throws(() => toOrdinal('foo'),           TypeError)
+  assert.throws(() => toOrdinal(null),            TypeError)
+  assert.throws(() => toOrdinal(undefined),       TypeError)
+  assert.throws(() => toOrdinal({ gender: 'f' }), TypeError)
+  assert.throws(() => toOrdinal([1, 2, 3]),       TypeError)
 })


### PR DESCRIPTION
## Resumen

- Añade tipos TypeScript nativos (`src/ordinales.d.ts`) — la librería es ahora consumible desde proyectos TS sin paquetes `@types` externos
- Define y documenta el comportamiento ante casos de borde: valores sin ordinal, floats y tipos inválidos
- Bump de versión a `2.1.0`

## Cambios

- `src/ordinales.d.ts` — tipos `OrdinalGender`, `OrdinalOptions`, `toOrdinal`, `enhance`
- `package.json` — campos `types` y `exports.types`; versión `2.1.0`
- `src/ordinales.js` — guardia `TypeError` para tipos inválidos (`NaN`, `string`, `null`, `undefined`, objetos, arrays); truncado de floats con `Math.trunc`
- `test.mjs` — tres nuevos bloques: valores sin ordinal, floats y tipos inválidos (9 tests en total)
- `demo.mjs` — sección de casos de borde con salida formateada
- `README.md` — sección "Casos de borde" con tabla de comportamiento
- `CHANGELOG.md` — entrada `2.1.0`

## Comportamiento de casos de borde

| Llamada | Resultado |
|---------|-----------|
| `toOrdinal(0)` | `''` |
| `toOrdinal(-5)` | `''` |
| `toOrdinal(1.9)` | `'primero'` |
| `toOrdinal(NaN)` | `TypeError` |
| `toOrdinal('foo')` | `TypeError` |
| `toOrdinal(null)` | `TypeError` |
| `toOrdinal(undefined)` | `TypeError` |
| `toOrdinal({ gender: 'f' })` | `TypeError` |

## Plan de pruebas

- [ ] `npm test` — 9/9 tests pasan
- [ ] `npm run demo` — salida correcta en ambas secciones
- [ ] Verificar que el `.d.ts` es reconocido por un editor con soporte TypeScript