### PR TITLE
chore: optimizar SEO — keywords, descripción, JSDoc y README v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ y este proyecto sigue [Versionado Semántico](https://semver.org/lang/es/).
 
 ---
 
+## [2.2.1] - 2026-05-16
+
+### Añadido
+- JSDoc completo en las funciones exportadas (`toOrdinal`, `enhance`) con descripción
+  bilingüe, `@param`, `@returns`, `@throws` y `@example`
+- Sección "Casos de uso" en el README con ejemplos reales de uso de la librería
+
+### Cambiado
+- Subtítulo del README: descripción en español con tagline en inglés en cursiva
+- Badge de tipos TypeScript: se añade badge dinámico de npm junto al estático
+- `keywords` y `description` en `package.json` optimizados para indexación en npm y GitHub
+
+---
+
 ## [2.2.0] - 2026-05-16
 
 ### Añadido

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@
 [![Bundle size](https://img.shields.io/bundlephobia/minzip/ordinales-js)](https://bundlephobia.com/package/ordinales-js)
 [![Sin dependencias](https://img.shields.io/badge/dependencias-cero-brightgreen)](https://www.npmjs.com/package/ordinales-js?activeTab=dependencies)
 [![TypeScript](https://img.shields.io/badge/TypeScript-ready-3178C6?logo=typescript&logoColor=white)](./src/ordinales.d.ts)
+[![Tipos](https://img.shields.io/npm/types/ordinales-js)](https://github.com/AndresSaa/ordinales-js/blob/master/src/ordinales.d.ts)
 [![Changelog](https://img.shields.io/badge/changelog-CHANGELOG.md-informational)](./CHANGELOG.md)
 
-Librería para convertir números cardinales a ordinales en español.
-Soporta género (masculino/femenino), apócope, abreviaturas tipográficas RAE y números hasta millones.
+Convierte números cardinales a ordinales en español, con soporte de género, apócope y abreviaturas tipográficas RAE.
+
+*Spanish ordinal numbers library with gender, apocope and typographic abbreviation support.*
 
 ## Requisitos
 
@@ -206,6 +208,18 @@ toOrdinal(1, { format: formato }) // '1.º'
 ```bash
 npm run demo
 ```
+
+## Casos de uso
+
+Cualquier interfaz que necesite expresar posiciones o rangos de forma escrita puede beneficiarse de esta librería.
+
+En **documentos legales y contratos notariales**, los ordinales escritos son requisito formal: cláusulas como "el vigésimo primer día del mes" o referencias a artículos ("el tercero del presente contrato") requieren precisión lingüística y de género. La opción `format: 'abbr'` cubre además las abreviaturas tipográficas RAE habituales en encabezados de documentos (1.º, 2.ª, 3.ᵉʳ).
+
+En **formularios web y aplicaciones de gestión** es común presentar pasos de procesos, ediciones o versiones como ordinales ("paso primero", "segunda edición"). La API acepta género y apócope para adaptarse al sustantivo que acompaña al ordinal sin lógica adicional en el cliente.
+
+En **generadores de facturas e informes** los ordinales aparecen en referencias de línea, secciones o trimestres: "primer trimestre", "segunda línea de pedido", "tercer concepto facturado". La abreviatura tipográfica (`format: 'abbr'`) cubre además encabezados de columna como 1.º, 2.º, 3.º
+
+En **listados y rankings** mostrados al usuario (clasificaciones, resultados paginados, posiciones en tablas) el femenino automático permite mostrar "primera posición" o "tercera participante" sin tablas de traducción adicionales.
 
 ## Contribuir
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ordinales-js",
-  "version": "2.2.0",
-  "description": "Librería para convertir números cardinales en ordinales",
+  "version": "2.2.1",
+  "description": "Librería para convertir números cardinales a ordinales en español. Spanish ordinal numbers library with gender and apocope support.",
   "main": "./src/index.js",
   "types": "./src/ordinales.d.ts",
   "exports": {
@@ -28,19 +28,17 @@
     "url": "git+https://github.com/AndresSaa/ordinales-js.git"
   },
   "keywords": [
-    "convertir",
-    "numeros",
     "ordinal",
     "ordinales",
-    "castellano",
+    "ordinal-es",
+    "spanish-ordinal",
+    "números-ordinales",
+    "spanish-numbers",
+    "ordinal-numbers",
     "español",
-    "js",
-    "javascript",
-    "module",
-    "modulo",
-    "lib",
-    "libreria",
-    "script"
+    "spanish",
+    "cardinal-to-ordinal",
+    "apocope"
   ],
   "author": "Andres Saa Narvaez <andres.saa.narvaez@gmail.com>",
   "license": "MIT",

--- a/src/ordinales.js
+++ b/src/ordinales.js
@@ -56,7 +56,25 @@ const buildParts = (n, gender = 'm') => {
   return parts
 }
 
-// Convierte un número a su forma ordinal en español, con opciones de género y apócope
+/**
+ * Convierte un número cardinal a su forma ordinal en español.
+ * Converts a cardinal number to its Spanish ordinal form.
+ *
+ * @param {number} numero - Número a convertir (entero positivo; los decimales se truncan)
+ * @param {'m'|'f'|Object} [opciones='m'] - Género abreviado o objeto de opciones
+ * @param {'m'|'f'} [opciones.gender='m'] - Género del ordinal
+ * @param {boolean} [opciones.apocope=false] - Aplica apócope (primero→primer, tercero→tercer)
+ * @param {'full'|'abbr'} [opciones.format='full'] - Formato: texto completo o abreviatura tipográfica RAE
+ * @param {boolean} [opciones.abbrDot=true] - Incluye punto en la abreviatura (1.º vs 1º)
+ * @returns {string} Ordinal en español, o cadena vacía para 0 y negativos
+ * @throws {TypeError} Si el primer argumento no es un número válido
+ *
+ * @example
+ * toOrdinal(1)                                    // 'primero'
+ * toOrdinal(1, 'f')                               // 'primera'
+ * toOrdinal(21, { gender: 'f', apocope: true })   // 'vigésima primera'
+ * toOrdinal(1, { format: 'abbr' })                // '1.º'
+ */
 const toOrdinal = (number, options = 'm') => {
   if (typeof number !== 'number' || isNaN(number)) throw new TypeError(`toOrdinal: se esperaba un número, se recibió ${typeof number}`)
 
@@ -80,7 +98,14 @@ const toOrdinal = (number, options = 'm') => {
   return apocope ? applyApocope(ordinal, gender) : ordinal
 }
 
-// Agrega el método toOrdinal al prototipo de Number
+/**
+ * Extiende el prototipo de Number con el método toOrdinal.
+ * Extends the Number prototype with the toOrdinal method.
+ *
+ * @example
+ * enhance()
+ * (21).toOrdinal('f') // 'vigésima primera'
+ */
 const enhance = () => addToPrototype(Number, 'toOrdinal', toOrdinal)
 
 module.exports = { toOrdinal, enhance }


### PR DESCRIPTION
## Resumen

- Mejoras de posicionamiento en npm y GitHub sin cambios en la API
- Bump de parche a `2.2.1`

## Cambios

- `package.json` — descripción bilingüe y keywords optimizados para indexación
- `README.md` — subtítulo con tagline en inglés, badge dinámico de tipos TypeScript, sección "Casos de uso" con ejemplos reales
- `src/ordinales.js` — JSDoc completo en `toOrdinal` y `enhance` con `@param`, `@returns`, `@throws` y `@example`
- `CHANGELOG.md` — entrada `2.2.1`

## Plan de pruebas

- [x] `npm test` — 14/14 tests pasan
- [ ] Verificar que los badges renderizan correctamente en GitHub