### PR TITLE
feat: abbrStyle 'plain' y superíndices consistentes en format: 'abbr'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ y este proyecto sigue [Versionado Semántico](https://semver.org/lang/es/).
 
 ---
 
+## [2.3.0] - 2026-05-17
+
+### Añadido
+- Opción `abbrStyle: 'super' | 'plain'` en `toOrdinal` (por defecto `'super'`)
+- `'plain'` devuelve la abreviatura en ASCII sin superíndices unicode: `1o`, `1a`, `1er`, `3er`
+- Nuevo tipo exportado `OrdinalAbbrStyle` en `src/ordinales.d.ts`
+- `abbrStyle` añadido a la interfaz `OrdinalOptions`
+
+### Cambiado
+- `format: 'abbr'` ahora usa modifier letters (`ᵒ` U+1D52, `ᵃ` U+1D43) en lugar de los
+  indicadores ordinales (`º` U+00BA, `ª` U+00AA), consistentes con `ᵉʳ` ya existente
+  y sin el subrayado que algunos navegadores aplican a los indicadores ordinales
+
+---
+
 ## [2.2.1] - 2026-05-16
 
 ### Añadido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ y este proyecto sigue [Versionado Semántico](https://semver.org/lang/es/).
 - `format: 'abbr'` ahora usa modifier letters (`ᵒ` U+1D52, `ᵃ` U+1D43) en lugar de los
   indicadores ordinales (`º` U+00BA, `ª` U+00AA), consistentes con `ᵉʳ` ya existente
   y sin el subrayado que algunos navegadores aplican a los indicadores ordinales
+- El apócope en `format: 'abbr'` ahora aplica a todos los ordinales cuyo último
+  componente es primero o tercero (`21.ᵉʳ`, `23.ᵉʳ`, `101.ᵉʳ`…), no solo a 1 y 3
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ toOrdinal(1,  { format: 'abbr' })                // '1.ᵒ'
 toOrdinal(1,  { gender: 'f', format: 'abbr' })   // '1.ᵃ'
 toOrdinal(3,  { apocope: true, format: 'abbr' }) // '3.ᵉʳ'
 toOrdinal(21, { gender: 'f', format: 'abbr' })   // '21.ᵃ'
-toOrdinal(21, { apocope: true, format: 'abbr' }) // '21.ᵒ'  (apócope solo aplica en 1.ᵉʳ y 3.ᵉʳ)
+toOrdinal(21, { apocope: true, format: 'abbr' }) // '21.ᵉʳ'
 ```
 
 El punto separador sigue la norma RAE y está activo por defecto. Se puede omitir con `abbrDot: false` para contextos donde se prefiere la forma sin punto:
@@ -155,7 +155,7 @@ toOrdinal(1,  { format: 'abbr', abbrStyle: 'plain' })                // '1o'
 toOrdinal(1,  { gender: 'f', format: 'abbr', abbrStyle: 'plain' })   // '1a'
 toOrdinal(3,  { apocope: true, format: 'abbr', abbrStyle: 'plain' }) // '3er'
 toOrdinal(21, { format: 'abbr', abbrStyle: 'plain' })                // '21o'
-toOrdinal(21, { apocope: true, format: 'abbr', abbrStyle: 'plain' }) // '21o'  (apócope solo aplica en 1er y 3er)
+toOrdinal(21, { apocope: true, format: 'abbr', abbrStyle: 'plain' }) // '21er'
 ```
 
 #### Números grandes

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ toOrdinal(21)                                     // 'vigésimo primero'
 toOrdinal(63, { gender: 'f' })                    // 'sexagésima tercera'
 toOrdinal(101, { apocope: true })                 // 'centésimo primer'
 toOrdinal(829)                                    // 'octingentésimo vigésimo noveno'
-toOrdinal(1,  { format: 'abbr' })                 // '1.º'
-toOrdinal(1,  { gender: 'f', format: 'abbr' })    // '1.ª'
+toOrdinal(1,  { format: 'abbr' })                 // '1.ᵒ'
+toOrdinal(1,  { gender: 'f', format: 'abbr' })    // '1.ᵃ'
 toOrdinal(1,  { apocope: true, format: 'abbr' })  // '1.ᵉʳ'
-toOrdinal(1,  { format: 'abbr', abbrDot: false }) // '1º'
+toOrdinal(1,  { format: 'abbr', abbrDot: false }) // '1ᵒ'
 ```
 
 **CommonJS**
@@ -54,16 +54,16 @@ toOrdinal(1,  { format: 'abbr', abbrDot: false }) // '1º'
 ```js
 const { toOrdinal } = require('ordinales-js')
 
-toOrdinal(1)                      // 'primero'
-toOrdinal(1, 'f')                 // 'primera'
-toOrdinal(1, { apocope: true })   // 'primer'
+toOrdinal(1)                     // 'primero'
+toOrdinal(1, 'f')                // 'primera'
+toOrdinal(1, { apocope: true })  // 'primer'
 ```
 
 **TypeScript**
 
 ```ts
 import { toOrdinal } from 'ordinales-js'
-import type { OrdinalGender, OrdinalOptions, OrdinalFormat } from 'ordinales-js'
+import type { OrdinalGender, OrdinalOptions, OrdinalFormat, OrdinalAbbrStyle } from 'ordinales-js'
 
 const opciones: OrdinalOptions = { gender: 'f', apocope: true }
 toOrdinal(21, opciones)           // 'vigésima primera'
@@ -72,7 +72,10 @@ const genero: OrdinalGender = 'f'
 toOrdinal(3, genero)              // 'tercera'
 
 const formato: OrdinalFormat = 'abbr'
-toOrdinal(1, { format: formato }) // '1.º'
+toOrdinal(1, { format: formato }) // '1.ᵒ'
+
+const estilo: OrdinalAbbrStyle = 'plain'
+toOrdinal(1, { format: 'abbr', abbrStyle: estilo }) // '1o'
 ```
 
 ## API
@@ -85,7 +88,7 @@ El segundo parámetro acepta un `string` de género o un objeto de opciones.
 |-------|---------|
 | `toOrdinal(n)` | género masculino por defecto |
 | `toOrdinal(n, 'f')` | género femenino |
-| `toOrdinal(n, { gender, apocope, format, abbrDot })` | objeto de opciones |
+| `toOrdinal(n, { gender, apocope, format, abbrDot, abbrStyle })` | objeto de opciones |
 
 #### Opciones
 
@@ -94,19 +97,20 @@ El segundo parámetro acepta un `string` de género o un objeto de opciones.
 | `gender` | `'m'` \| `'f'` | `'m'` | Género del ordinal |
 | `apocope` | `boolean` | `false` | Aplica apócope (`primero` → `primer`, `tercero` → `tercer`) |
 | `format` | `'full'` \| `'abbr'` | `'full'` | `'abbr'` devuelve la abreviatura tipográfica RAE con superíndice unicode |
-| `abbrDot` | `boolean` | `true` | Incluye el punto separador en `'abbr'` (`1.º` vs `1º`). Solo aplica cuando `format: 'abbr'` |
+| `abbrDot` | `boolean` | `true` | Incluye el punto separador en `'abbr'` (`1.ᵒ` vs `1ᵒ`). Solo aplica cuando `format: 'abbr'` y `abbrStyle: 'super'` |
+| `abbrStyle` | `'super'` \| `'plain'` | `'super'` | `'plain'` devuelve texto ASCII sin superíndices (`1o`, `1a`, `1er`). Útil para email o contextos sin soporte unicode completo |
 
 #### Género
 
 ```js
 // Forma abreviada (string)
-toOrdinal(1, 'm')               // 'primero'
-toOrdinal(1, 'f')               // 'primera'
+toOrdinal(1, 'm')              // 'primero'
+toOrdinal(1, 'f')              // 'primera'
 
 // Forma objeto
-toOrdinal(1,  { gender: 'f' })  // 'primera'
-toOrdinal(21, { gender: 'f' })  // 'vigésima primera'
-toOrdinal(63, { gender: 'f' })  // 'sexagésima tercera'
+toOrdinal(1,  { gender: 'f' }) // 'primera'
+toOrdinal(21, { gender: 'f' }) // 'vigésima primera'
+toOrdinal(63, { gender: 'f' }) // 'sexagésima tercera'
 ```
 
 #### Apócope
@@ -124,34 +128,46 @@ toOrdinal(1, { gender: 'f', apocope: true }) // 'primera'
 
 #### Abreviatura tipográfica (`format: 'abbr'`)
 
-Devuelve la forma abreviada oficial RAE usando superíndices unicode (`.º`, `.ª`, `.ᵉʳ`).
+Devuelve la forma abreviada oficial RAE usando superíndices unicode (`.ᵒ`, `.ᵃ`, `.ᵉʳ`).
 
 ```js
-toOrdinal(1,  { format: 'abbr' })                // '1.º'
-toOrdinal(1,  { gender: 'f', format: 'abbr' })   // '1.ª'
+toOrdinal(1,  { format: 'abbr' })                // '1.ᵒ'
+toOrdinal(1,  { gender: 'f', format: 'abbr' })   // '1.ᵃ'
 toOrdinal(3,  { apocope: true, format: 'abbr' }) // '3.ᵉʳ'
-toOrdinal(21, { gender: 'f', format: 'abbr' })   // '21.ª'
-toOrdinal(21, { apocope: true, format: 'abbr' }) // '21.º'  (apócope solo aplica en 1.ᵉʳ y 3.ᵉʳ)
+toOrdinal(21, { gender: 'f', format: 'abbr' })   // '21.ᵃ'
+toOrdinal(21, { apocope: true, format: 'abbr' }) // '21.ᵒ'  (apócope solo aplica en 1.ᵉʳ y 3.ᵉʳ)
 ```
 
 El punto separador sigue la norma RAE y está activo por defecto. Se puede omitir con `abbrDot: false` para contextos donde se prefiere la forma sin punto:
 
 ```js
-toOrdinal(1,  { format: 'abbr', abbrDot: false })                // '1º'
-toOrdinal(1,  { gender: 'f', format: 'abbr', abbrDot: false })   // '1ª'
+toOrdinal(1,  { format: 'abbr', abbrDot: false })                // '1ᵒ'
+toOrdinal(1,  { gender: 'f', format: 'abbr', abbrDot: false })   // '1ᵃ'
 toOrdinal(3,  { apocope: true, format: 'abbr', abbrDot: false }) // '3ᵉʳ'
+```
+
+#### Abreviatura en texto plano (`abbrStyle: 'plain'`)
+
+Devuelve la abreviatura sin superíndices unicode, en ASCII puro. Útil para email, hojas de cálculo o cualquier contexto donde los superíndices no se renderizan correctamente. `abbrDot` no tiene efecto en este modo.
+
+```js
+toOrdinal(1,  { format: 'abbr', abbrStyle: 'plain' })                // '1o'
+toOrdinal(1,  { gender: 'f', format: 'abbr', abbrStyle: 'plain' })   // '1a'
+toOrdinal(3,  { apocope: true, format: 'abbr', abbrStyle: 'plain' }) // '3er'
+toOrdinal(21, { format: 'abbr', abbrStyle: 'plain' })                // '21o'
+toOrdinal(21, { apocope: true, format: 'abbr', abbrStyle: 'plain' }) // '21o'  (apócope solo aplica en 1er y 3er)
 ```
 
 #### Números grandes
 
 ```js
-toOrdinal(10000)                        // 'décimo milésimo'
-toOrdinal(21000)                        // 'vigésimo primer milésimo'
-toOrdinal(21000, 'f')                   // 'vigésima primera milésima'
-toOrdinal(123456)                       // 'centésimo vigésimo tercer milésimo cuadrigentésimo quincuagésimo sexto'
-toOrdinal(1000000)                      // 'millonésimo'
-toOrdinal(2000000)                      // 'dosmillonésimo'
-toOrdinal(21000000, { apocope: true })  // 'vigésimo primer millonésimo'
+toOrdinal(10000)                       // 'décimo milésimo'
+toOrdinal(21000)                       // 'vigésimo primer milésimo'
+toOrdinal(21000, 'f')                  // 'vigésima primera milésima'
+toOrdinal(123456)                      // 'centésimo vigésimo tercer milésimo cuadrigentésimo quincuagésimo sexto'
+toOrdinal(1000000)                     // 'millonésimo'
+toOrdinal(2000000)                     // 'dosmillonésimo'
+toOrdinal(21000000, { apocope: true }) // 'vigésimo primer millonésimo'
 ```
 
 ### `enhance()`
@@ -161,16 +177,19 @@ Extiende el prototipo de `Number` para usar `toOrdinal` directamente sobre cualq
 ```js
 // ESM
 import { enhance } from 'ordinales-js'
+
 // CJS
 const { enhance } = require('ordinales-js')
+```
 
+```js
 enhance()
 
 const numero = 21
-numero.toOrdinal()                    // 'vigésimo primero'
-numero.toOrdinal('f')                 // 'vigésima primera'
-numero.toOrdinal({ gender: 'f' })     // 'vigésima primera'
-numero.toOrdinal({ apocope: true })   // 'vigésimo primer'
+numero.toOrdinal()                  // 'vigésimo primero'
+numero.toOrdinal('f')               // 'vigésima primera'
+numero.toOrdinal({ gender: 'f' })   // 'vigésima primera'
+numero.toOrdinal({ apocope: true }) // 'vigésimo primer'
 ```
 
 ### Tipos TypeScript
@@ -178,7 +197,7 @@ numero.toOrdinal({ apocope: true })   // 'vigésimo primer'
 El paquete incluye tipos nativos, sin necesidad de instalar `@types/ordinales-js`.
 
 ```ts
-import type { OrdinalGender, OrdinalOptions, OrdinalFormat } from 'ordinales-js'
+import type { OrdinalGender, OrdinalOptions, OrdinalFormat, OrdinalAbbrStyle } from 'ordinales-js'
 
 const opciones: OrdinalOptions = { gender: 'f', apocope: true }
 toOrdinal(21, opciones)           // 'vigésima primera'
@@ -187,7 +206,10 @@ const genero: OrdinalGender = 'f'
 toOrdinal(3, genero)              // 'tercera'
 
 const formato: OrdinalFormat = 'abbr'
-toOrdinal(1, { format: formato }) // '1.º'
+toOrdinal(1, { format: formato }) // '1.ᵒ'
+
+const estilo: OrdinalAbbrStyle = 'plain'
+toOrdinal(1, { format: 'abbr', abbrStyle: estilo }) // '1o'
 ```
 
 ## Casos de borde
@@ -213,11 +235,11 @@ npm run demo
 
 Cualquier interfaz que necesite expresar posiciones o rangos de forma escrita puede beneficiarse de esta librería.
 
-En **documentos legales y contratos notariales**, los ordinales escritos son requisito formal: cláusulas como "el vigésimo primer día del mes" o referencias a artículos ("el tercero del presente contrato") requieren precisión lingüística y de género. La opción `format: 'abbr'` cubre además las abreviaturas tipográficas RAE habituales en encabezados de documentos (1.º, 2.ª, 3.ᵉʳ).
+En **documentos legales y contratos notariales**, los ordinales escritos son requisito formal: cláusulas como "el vigésimo primer día del mes" o referencias a artículos ("el tercero del presente contrato") requieren precisión lingüística y de género. La opción `format: 'abbr'` cubre además las abreviaturas tipográficas RAE habituales en encabezados de documentos (1.ᵒ, 2.ᵃ, 3.ᵉʳ).
 
 En **formularios web y aplicaciones de gestión** es común presentar pasos de procesos, ediciones o versiones como ordinales ("paso primero", "segunda edición"). La API acepta género y apócope para adaptarse al sustantivo que acompaña al ordinal sin lógica adicional en el cliente.
 
-En **generadores de facturas e informes** los ordinales aparecen en referencias de línea, secciones o trimestres: "primer trimestre", "segunda línea de pedido", "tercer concepto facturado". La abreviatura tipográfica (`format: 'abbr'`) cubre además encabezados de columna como 1.º, 2.º, 3.º
+En **generadores de facturas e informes** los ordinales aparecen en referencias de línea, secciones o trimestres: "primer trimestre", "segunda línea de pedido", "tercer concepto facturado". La abreviatura tipográfica (`format: 'abbr'`) cubre encabezados de columna como 1.ᵒ, 2.ᵒ, 3.ᵒ, y `abbrStyle: 'plain'` permite exportar a formatos que no soportan superíndices unicode (Excel legacy, CSV, email).
 
 En **listados y rankings** mostrados al usuario (clasificaciones, resultados paginados, posiciones en tablas) el femenino automático permite mostrar "primera posición" o "tercera participante" sin tablas de traducción adicionales.
 

--- a/demo.mjs
+++ b/demo.mjs
@@ -41,6 +41,19 @@ numeros.forEach(n => {
   console.log(`${col1} | ${col2} | ${col3} | ${col4}`)
 })
 
+console.log("\n--- ABREVIATURAS TEXTO PLANO (format: 'abbr', abbrStyle: 'plain') ---\n")
+
+console.log("NUM      | ABREV. (M) | ABREV. APÓCOPE | ABREV. FEMENINO")
+console.log("---------|------------|----------------|----------------")
+
+numeros.forEach(n => {
+  const col1 = n.toString().padEnd(8)
+  const col2 = toOrdinal(n, { format: 'abbr', abbrStyle: 'plain' }).padEnd(10)
+  const col3 = toOrdinal(n, { apocope: true, format: 'abbr', abbrStyle: 'plain' }).padEnd(14)
+  const col4 = toOrdinal(n, { gender: 'f', format: 'abbr', abbrStyle: 'plain' })
+  console.log(`${col1} | ${col2} | ${col3} | ${col4}`)
+})
+
 console.log("\n----------------------------------\n")
 
 console.log("--- CASOS DE BORDE ---\n")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ordinales-js",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Librería para convertir números cardinales a ordinales en español. Spanish ordinal numbers library with gender and apocope support.",
   "main": "./src/index.js",
   "types": "./src/ordinales.d.ts",

--- a/src/ordinales.d.ts
+++ b/src/ordinales.d.ts
@@ -1,11 +1,13 @@
 export type OrdinalGender = 'm' | 'f'
 export type OrdinalFormat = 'full' | 'abbr'
+export type OrdinalAbbrStyle = 'super' | 'plain'
 
 export interface OrdinalOptions {
   gender?: OrdinalGender
   apocope?: boolean
   format?: OrdinalFormat
   abbrDot?: boolean
+  abbrStyle?: OrdinalAbbrStyle
 }
 
 export function toOrdinal(n: number, options?: OrdinalGender | OrdinalOptions): string

--- a/src/ordinales.js
+++ b/src/ordinales.js
@@ -90,11 +90,11 @@ const toOrdinal = (number, options = 'm') => {
   if (format === 'abbr') {
     if (n <= 0) return ''
     if (abbrStyle === 'plain') {
-      if (apocope && gender !== 'f' && (n === 1 || n === 3)) return `${n}er`
+      if (apocope && gender !== 'f' && (n % 10 === 1 || n % 10 === 3)) return `${n}er`
       return `${n}${gender === 'f' ? 'a' : 'o'}`
     }
     const sep = abbrDot ? '.' : ''
-    if (apocope && gender !== 'f' && (n === 1 || n === 3)) return `${n}${sep}ᵉʳ`
+    if (apocope && gender !== 'f' && (n % 10 === 1 || n % 10 === 3)) return `${n}${sep}ᵉʳ`
     return `${n}${sep}${gender === 'f' ? 'ᵃ' : 'ᵒ'}`
   }
 

--- a/src/ordinales.js
+++ b/src/ordinales.js
@@ -65,7 +65,8 @@ const buildParts = (n, gender = 'm') => {
  * @param {'m'|'f'} [opciones.gender='m'] - Género del ordinal
  * @param {boolean} [opciones.apocope=false] - Aplica apócope (primero→primer, tercero→tercer)
  * @param {'full'|'abbr'} [opciones.format='full'] - Formato: texto completo o abreviatura tipográfica RAE
- * @param {boolean} [opciones.abbrDot=true] - Incluye punto en la abreviatura (1.º vs 1º)
+ * @param {boolean} [opciones.abbrDot=true] - Incluye punto en la abreviatura (1.ᵒ vs 1ᵒ)
+ * @param {'super'|'plain'} [opciones.abbrStyle='super'] - Estilo de abbr: superíndices unicode o texto plano (1o, 1a, 1er)
  * @returns {string} Ordinal en español, o cadena vacía para 0 y negativos
  * @throws {TypeError} Si el primer argumento no es un número válido
  *
@@ -73,22 +74,28 @@ const buildParts = (n, gender = 'm') => {
  * toOrdinal(1)                                    // 'primero'
  * toOrdinal(1, 'f')                               // 'primera'
  * toOrdinal(21, { gender: 'f', apocope: true })   // 'vigésima primera'
- * toOrdinal(1, { format: 'abbr' })                // '1.º'
+ * toOrdinal(1, { format: 'abbr' })                // '1.ᵒ'
+ * toOrdinal(1, { format: 'abbr', abbrStyle: 'plain' }) // '1o'
  */
 const toOrdinal = (number, options = 'm') => {
   if (typeof number !== 'number' || isNaN(number)) throw new TypeError(`toOrdinal: se esperaba un número, se recibió ${typeof number}`)
 
-  const n       = Math.trunc(number)
-  const gender  = typeof options === 'object' ? (options.gender  ?? 'm')    : options
-  const apocope = typeof options === 'object' ? (options.apocope ?? false)  : false
-  const format  = typeof options === 'object' ? (options.format  ?? 'full') : 'full'
-  const abbrDot = typeof options === 'object' ? (options.abbrDot ?? true)   : true
+  const n         = Math.trunc(number)
+  const gender    = typeof options === 'object' ? (options.gender    ?? 'm')           : options
+  const apocope   = typeof options === 'object' ? (options.apocope   ?? false)         : false
+  const format    = typeof options === 'object' ? (options.format    ?? 'full')        : 'full'
+  const abbrDot   = typeof options === 'object' ? (options.abbrDot   ?? true)          : true
+  const abbrStyle = typeof options === 'object' ? (options.abbrStyle ?? 'super') : 'super'
 
   if (format === 'abbr') {
     if (n <= 0) return ''
+    if (abbrStyle === 'plain') {
+      if (apocope && gender !== 'f' && (n === 1 || n === 3)) return `${n}er`
+      return `${n}${gender === 'f' ? 'a' : 'o'}`
+    }
     const sep = abbrDot ? '.' : ''
     if (apocope && gender !== 'f' && (n === 1 || n === 3)) return `${n}${sep}ᵉʳ`
-    return `${n}${sep}${gender === 'f' ? 'ª' : 'º'}`
+    return `${n}${sep}${gender === 'f' ? 'ᵃ' : 'ᵒ'}`
   }
 
   const ordinal = buildParts(n, gender)

--- a/test.mjs
+++ b/test.mjs
@@ -61,35 +61,47 @@ test('casos de borde — floats se truncan', () => {
 })
 
 test('format abbr — masculino por defecto', () => {
-  assert.strictEqual(toOrdinal(1,  { format: 'abbr' }), '1.º')
-  assert.strictEqual(toOrdinal(2,  { format: 'abbr' }), '2.º')
-  assert.strictEqual(toOrdinal(21, { format: 'abbr' }), '21.º')
+  assert.strictEqual(toOrdinal(1,  { format: 'abbr' }), '1.ᵒ')
+  assert.strictEqual(toOrdinal(2,  { format: 'abbr' }), '2.ᵒ')
+  assert.strictEqual(toOrdinal(21, { format: 'abbr' }), '21.ᵒ')
 })
 
 test('format abbr — femenino', () => {
-  assert.strictEqual(toOrdinal(1,  { gender: 'f', format: 'abbr' }), '1.ª')
-  assert.strictEqual(toOrdinal(3,  { gender: 'f', format: 'abbr' }), '3.ª')
-  assert.strictEqual(toOrdinal(21, { gender: 'f', format: 'abbr' }), '21.ª')
+  assert.strictEqual(toOrdinal(1,  { gender: 'f', format: 'abbr' }), '1.ᵃ')
+  assert.strictEqual(toOrdinal(3,  { gender: 'f', format: 'abbr' }), '3.ᵃ')
+  assert.strictEqual(toOrdinal(21, { gender: 'f', format: 'abbr' }), '21.ᵃ')
 })
 
 test('format abbr — apócope solo en 1 y 3 masculino', () => {
   assert.strictEqual(toOrdinal(1,  { apocope: true, format: 'abbr' }), '1.ᵉʳ')
   assert.strictEqual(toOrdinal(3,  { apocope: true, format: 'abbr' }), '3.ᵉʳ')
-  assert.strictEqual(toOrdinal(21, { apocope: true, format: 'abbr' }), '21.º')
-  assert.strictEqual(toOrdinal(1,  { gender: 'f', apocope: true, format: 'abbr' }), '1.ª')
+  assert.strictEqual(toOrdinal(21, { apocope: true, format: 'abbr' }), '21.ᵒ')
+  assert.strictEqual(toOrdinal(1,  { gender: 'f', apocope: true, format: 'abbr' }), '1.ᵃ')
 })
 
 test('format abbr — abbrDot: false omite el punto', () => {
-  assert.strictEqual(toOrdinal(1,  { format: 'abbr', abbrDot: false }), '1º')
-  assert.strictEqual(toOrdinal(1,  { gender: 'f', format: 'abbr', abbrDot: false }), '1ª')
+  assert.strictEqual(toOrdinal(1,  { format: 'abbr', abbrDot: false }), '1ᵒ')
+  assert.strictEqual(toOrdinal(1,  { gender: 'f', format: 'abbr', abbrDot: false }), '1ᵃ')
   assert.strictEqual(toOrdinal(3,  { apocope: true, format: 'abbr', abbrDot: false }), '3ᵉʳ')
-  assert.strictEqual(toOrdinal(21, { format: 'abbr', abbrDot: false }), '21º')
+  assert.strictEqual(toOrdinal(21, { format: 'abbr', abbrDot: false }), '21ᵒ')
 })
 
 test('format abbr — casos de borde', () => {
   assert.strictEqual(toOrdinal(0,   { format: 'abbr' }), '')
   assert.strictEqual(toOrdinal(-1,  { format: 'abbr' }), '')
-  assert.strictEqual(toOrdinal(1.9, { format: 'abbr' }), '1.º')
+  assert.strictEqual(toOrdinal(1.9, { format: 'abbr' }), '1.ᵒ')
+})
+
+test('format abbr — abbrStyle: plain', () => {
+  assert.strictEqual(toOrdinal(1,  { format: 'abbr', abbrStyle: 'plain' }), '1o')
+  assert.strictEqual(toOrdinal(2,  { format: 'abbr', abbrStyle: 'plain' }), '2o')
+  assert.strictEqual(toOrdinal(21, { format: 'abbr', abbrStyle: 'plain' }), '21o')
+  assert.strictEqual(toOrdinal(1,  { gender: 'f', format: 'abbr', abbrStyle: 'plain' }), '1a')
+  assert.strictEqual(toOrdinal(21, { gender: 'f', format: 'abbr', abbrStyle: 'plain' }), '21a')
+  assert.strictEqual(toOrdinal(1,  { apocope: true, format: 'abbr', abbrStyle: 'plain' }), '1er')
+  assert.strictEqual(toOrdinal(3,  { apocope: true, format: 'abbr', abbrStyle: 'plain' }), '3er')
+  assert.strictEqual(toOrdinal(21, { apocope: true, format: 'abbr', abbrStyle: 'plain' }), '21o')
+  assert.strictEqual(toOrdinal(1,  { gender: 'f', apocope: true, format: 'abbr', abbrStyle: 'plain' }), '1a')
 })
 
 test('casos de borde — tipos inválidos lanzan TypeError', () => {

--- a/test.mjs
+++ b/test.mjs
@@ -72,11 +72,16 @@ test('format abbr — femenino', () => {
   assert.strictEqual(toOrdinal(21, { gender: 'f', format: 'abbr' }), '21.ᵃ')
 })
 
-test('format abbr — apócope solo en 1 y 3 masculino', () => {
-  assert.strictEqual(toOrdinal(1,  { apocope: true, format: 'abbr' }), '1.ᵉʳ')
-  assert.strictEqual(toOrdinal(3,  { apocope: true, format: 'abbr' }), '3.ᵉʳ')
-  assert.strictEqual(toOrdinal(21, { apocope: true, format: 'abbr' }), '21.ᵒ')
-  assert.strictEqual(toOrdinal(1,  { gender: 'f', apocope: true, format: 'abbr' }), '1.ᵃ')
+test('format abbr — apócope cuando el último componente es primero o tercero', () => {
+  assert.strictEqual(toOrdinal(1,   { apocope: true, format: 'abbr' }), '1.ᵉʳ')
+  assert.strictEqual(toOrdinal(3,   { apocope: true, format: 'abbr' }), '3.ᵉʳ')
+  assert.strictEqual(toOrdinal(21,  { apocope: true, format: 'abbr' }), '21.ᵉʳ')
+  assert.strictEqual(toOrdinal(23,  { apocope: true, format: 'abbr' }), '23.ᵉʳ')
+  assert.strictEqual(toOrdinal(101, { apocope: true, format: 'abbr' }), '101.ᵉʳ')
+  assert.strictEqual(toOrdinal(10,  { apocope: true, format: 'abbr' }), '10.ᵒ')
+  assert.strictEqual(toOrdinal(20,  { apocope: true, format: 'abbr' }), '20.ᵒ')
+  assert.strictEqual(toOrdinal(1,   { gender: 'f', apocope: true, format: 'abbr' }), '1.ᵃ')
+  assert.strictEqual(toOrdinal(21,  { gender: 'f', apocope: true, format: 'abbr' }), '21.ᵃ')
 })
 
 test('format abbr — abbrDot: false omite el punto', () => {
@@ -93,15 +98,18 @@ test('format abbr — casos de borde', () => {
 })
 
 test('format abbr — abbrStyle: plain', () => {
-  assert.strictEqual(toOrdinal(1,  { format: 'abbr', abbrStyle: 'plain' }), '1o')
-  assert.strictEqual(toOrdinal(2,  { format: 'abbr', abbrStyle: 'plain' }), '2o')
-  assert.strictEqual(toOrdinal(21, { format: 'abbr', abbrStyle: 'plain' }), '21o')
-  assert.strictEqual(toOrdinal(1,  { gender: 'f', format: 'abbr', abbrStyle: 'plain' }), '1a')
-  assert.strictEqual(toOrdinal(21, { gender: 'f', format: 'abbr', abbrStyle: 'plain' }), '21a')
-  assert.strictEqual(toOrdinal(1,  { apocope: true, format: 'abbr', abbrStyle: 'plain' }), '1er')
-  assert.strictEqual(toOrdinal(3,  { apocope: true, format: 'abbr', abbrStyle: 'plain' }), '3er')
-  assert.strictEqual(toOrdinal(21, { apocope: true, format: 'abbr', abbrStyle: 'plain' }), '21o')
-  assert.strictEqual(toOrdinal(1,  { gender: 'f', apocope: true, format: 'abbr', abbrStyle: 'plain' }), '1a')
+  assert.strictEqual(toOrdinal(1,   { format: 'abbr', abbrStyle: 'plain' }), '1o')
+  assert.strictEqual(toOrdinal(2,   { format: 'abbr', abbrStyle: 'plain' }), '2o')
+  assert.strictEqual(toOrdinal(21,  { format: 'abbr', abbrStyle: 'plain' }), '21o')
+  assert.strictEqual(toOrdinal(1,   { gender: 'f', format: 'abbr', abbrStyle: 'plain' }), '1a')
+  assert.strictEqual(toOrdinal(21,  { gender: 'f', format: 'abbr', abbrStyle: 'plain' }), '21a')
+  assert.strictEqual(toOrdinal(1,   { apocope: true, format: 'abbr', abbrStyle: 'plain' }), '1er')
+  assert.strictEqual(toOrdinal(3,   { apocope: true, format: 'abbr', abbrStyle: 'plain' }), '3er')
+  assert.strictEqual(toOrdinal(21,  { apocope: true, format: 'abbr', abbrStyle: 'plain' }), '21er')
+  assert.strictEqual(toOrdinal(23,  { apocope: true, format: 'abbr', abbrStyle: 'plain' }), '23er')
+  assert.strictEqual(toOrdinal(10,  { apocope: true, format: 'abbr', abbrStyle: 'plain' }), '10o')
+  assert.strictEqual(toOrdinal(1,   { gender: 'f', apocope: true, format: 'abbr', abbrStyle: 'plain' }), '1a')
+  assert.strictEqual(toOrdinal(21,  { gender: 'f', apocope: true, format: 'abbr', abbrStyle: 'plain' }), '21a')
 })
 
 test('casos de borde — tipos inválidos lanzan TypeError', () => {


### PR DESCRIPTION
## Resumen

- Sustituye los indicadores ordinales `º` (U+00BA) y `ª` (U+00AA) por modifier letters `ᵒ` (U+1D52) y `ᵃ` (U+1D43), consistentes con `ᵉʳ` ya existente en el apócope. Elimina el subrayado que algunos navegadores aplican implícitamente a los ordinal indicators.
- Nueva opción `abbrStyle: 'super' | 'plain'` (por defecto `'super'`). `'plain'` devuelve abreviaturas en ASCII puro sin superíndices unicode: `1o`, `1a`, `1er`. Útil para email, Excel legacy o cualquier contexto sin soporte de superíndices. `abbrDot` no aplica en modo `'plain'`.
- Nuevo tipo exportado `OrdinalAbbrStyle` en `src/ordinales.d.ts`.

## Cambios

- `src/ordinales.js` — lógica de `abbrStyle`
- `src/ordinales.d.ts` — tipo `OrdinalAbbrStyle` e interfaz `OrdinalOptions`
- `test.mjs` — nuevo bloque `format abbr — abbrStyle: plain` (15 tests en total)
- `README.md` — tabla de opciones, nueva sección `abbrStyle: 'plain'`, ejemplo TypeScript
- `CHANGELOG.md` — entrada v2.3.0
- `demo.mjs` — nueva tabla de abreviaturas en texto plano

## Plan de pruebas

- [x] `npm test` — 15/15 pasan
- [ ] `npm run demo` — tabla plain muestra `1o`, `1a`, `1er` correctamente
- [ ] Merge con **Rebase and merge** para mantener historial lineal